### PR TITLE
MNT: try and embed discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ to
     <link rel="stylesheet" href="_static/mpl.css?v2" type="text/css" />
 ```
 
-The query parameter will be ignored when serving the file from the origin but
+The query parameter will be ignored when serving the file from the origin, but
 will be taken into consideration by both cloudflare and users browsers when
 identifying cache hits.

--- a/docs/_static/css/landing.css
+++ b/docs/_static/css/landing.css
@@ -414,7 +414,7 @@ main {
 
 @media (min-width: 800px) {
   main {
-    margin-top: 50px;
+    margin-top: 20px;
     grid-template-columns:
       minmax(1em, auto) minmax(44px, 118px) minmax(44px, 118px)
       minmax(44px, 118px) minmax(44px, 118px) minmax(44px, 118px) minmax(

--- a/docs/body.html
+++ b/docs/body.html
@@ -130,7 +130,7 @@
           <!-- optional important news -->
           <h3>News</h3>
           
-          <d-topics-list discourse-url="https://discourse.matplotlib.org/" per-page="5">
+          <d-topics-list discourse-url="https://discourse.matplotlib.org/" category="14" per-page="5">
           </d-topics-list>
         </div>
         <!-- END NEWS ITEMS -->
@@ -464,4 +464,4 @@
         </ul>
       </section>
       <script src="_static/script.js"></script>
-      <script src="http://discourse.matplotlib.org/javascripts/embed-topics.js"></script>
+      <script src="https://discourse.matplotlib.org/javascripts/embed-topics.js"></script>

--- a/docs/body.html
+++ b/docs/body.html
@@ -129,30 +129,10 @@
           <!-- make these easier to visually differentiate !-->
           <!-- optional important news -->
           <h3>News</h3>
-          <div class="news__item--highlight">
-            <h5 class="date">March 30, 2021</h5>
-            <h4 class="title">Matplotlib 3.4.1 Released</h4>
-            <p>
-              This is the first bug-fix release for the 3.4 series and includes
-              critical bug fixes for 3D scatters.
-            </p>
-            <a href="" class="link--offsite">Matplotlib 3.4.1 Released</a>
-          </div>
-
-          <!-- START NEWS ITEMS -->
-          <div class="news__item">
-            <h5 class="date">March 30, 2021</h5>
-            <a href="" class="link--offsite">Matplotlib 3.4.0 release</a>
-          </div>
-
-          <div class="news__item">
-            <h5 class="date">March 11, 2021</h5>
-            <a href="" class="link--offsite">
-              Matplotlib 3.4.0 release candidate 3
-            </a>
-          </div>
+          
+          <d-topics-list discourse-url="https://discourse.matplotlib.org/" per-page="5">
+          </d-topics-list>
         </div>
-
         <!-- END NEWS ITEMS -->
         <!-- link to discourse -->
         <div class="news__discourse-link">
@@ -484,3 +464,4 @@
         </ul>
       </section>
       <script src="_static/script.js"></script>
+      <script src="http://discourse.matplotlib.org/javascripts/embed-topics.js"></script>

--- a/docs/body.html
+++ b/docs/body.html
@@ -130,7 +130,7 @@
           <!-- optional important news -->
           <h3>News</h3>
           
-          <d-topics-list discourse-url="https://discourse.matplotlib.org/" category="14" per-page="5">
+          <d-topics-list discourse-url="https://discourse.matplotlib.org/" category="10" per-page="5">
           </d-topics-list>
         </div>
         <!-- END NEWS ITEMS -->
@@ -138,7 +138,7 @@
         <div class="news__discourse-link">
           <div class="rule"></div>
           <a
-            href="https://discourse.matplotlib.org/c/announce/14"
+            href="https://discourse.matplotlib.org/c/announce/matplotlib-announce/10"
             class="link--offsite"
             >Older Announcements</a
           >


### PR DESCRIPTION
Not 100% sure this is working, because you need to allow discourse to embed only certain websites.  But this should allow us to embed the discourse Announces in the News section.  

### References:

- https://meta.discourse.org/t/embedding-a-list-of-discourse-topics-in-another-site/125911
- https://meta.discourse.org/t/csp-frame-ancestors-enabled-by-default/197615