### PR TITLE
publish the html directory to gh-pages

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,5 +16,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build
+          publish_dir: ./docs/_build/html
           force_orphan: true


### PR DESCRIPTION
This is needed to get the link to the temporary site mentioned in the README to work.