### PR TITLE
Fix some issues in the footer

### DIFF
--- a/docs/_static/css/landing.css
+++ b/docs/_static/css/landing.css
@@ -377,6 +377,7 @@ ul.mpl-links,
 ul.release-docs {
   list-style-type: none;
   padding: 0;
+  margin-top: 1.33em;
 }
 
 ul.mpl-links li,

--- a/docs/_templates/landing_footer.html
+++ b/docs/_templates/landing_footer.html
@@ -51,7 +51,7 @@
       <li>
         <a href="https://github.com/matplotlib/governance">Governance</a>
       </li>
-      <li><a href="">NumFOCUS Fiscally Sponsered Project</a></li>
+      <li><a href="">NumFOCUS Fiscally Sponsored Project</a></li>
     </ul>
 
     <ul class="release-docs grid__release-docs">

--- a/docs/_templates/landing_footer.html
+++ b/docs/_templates/landing_footer.html
@@ -3,30 +3,27 @@
       <h1>matplotlib</h1>
       <ul class="social fas">
         <li>
-          <a
-            href="https://github.com/matplotlib/matplotlib"
-            aria-label="Matplotlib on Github"
-          >
+          <a href="https://github.com/matplotlib/matplotlib" aria-label="Matplotlib on Github">
             <i class="fab fa-github" aria-hidden="true"></i>
           </a>
         </li>
         <li class="social__twitter">
-          <a href="" aria-label="Matplotlib on Twitter">
+          <a href="https://twitter.com/matplotlib" aria-label="Matplotlib on Twitter">
             <i class="fab fa-twitter" aria-hidden="true"></i>
           </a>
         </li>
-        <li class="social__stackoverflow">
-          <a href="" aria-label="Matplotlib on Stack Overflow">
-            <i class="fab fa-stack-overflow" aria-hidden="true"></i>
+        <li class="social__discourse">
+          <a href="https://discourse.matplotlib.org" aria-label="Matplotlib Discourse">
+            <i class="fab fa-discourse" aria-hidden="true"></i>
           </a>
         </li>
         <li class="social__gitter">
-          <a href="" aria-label="Matplotlib on Gitter">
+          <a href="https://gitter.im/matplotlib/matplotlib" aria-label="Matplotlib on Gitter">
             <i class="fab fa-gitter" aria-hidden="true"></i>
           </a>
         </li>
         <li class="social__instagran">
-          <a href="" aria-label="Matplotlib on Instagram">
+          <a href="https://instagram.com/matplotart" aria-label="Matplotlib on Instagram">
             <i class="fab fa-instagram" aria-hidden="true"></i>
           </a>
         </li>


### PR DESCRIPTION
Adds most of the links and changes Stack Overflow to Discourse to match the header. (I also don't know where the NumFOCUS 'sponsored' link should point.)

Also fixes alignment, as the 3 columns had different margins.