### PR TITLE
FIX: put rotator script at end

### DIFF
--- a/docs/_static/script.js
+++ b/docs/_static/script.js
@@ -44,15 +44,6 @@ window.addEventListener("DOMContentLoaded", () => {
       tabs[tabFocus].focus();
     }
   });
-  ///////////////////////////////////////
-  // rotate images in images-rotate directory:
-  var ind = getRandomInt(images_rotate.length); 
-  var im = images_rotate[ind].image;
-  st = '<img class="imrot-img" src="_static/images-rotate/' +im+'" />'
-  var cap = images_rotate[ind].caption;
-  var link = "https://matplotlib.org/stable/" + images_rotate[ind].link;
-  st2 = '<div class="imrot-cap">'+ cap + '</div>'
-  document.getElementById('image_rotator').innerHTML = '<a href="' + link + '"> ' + st + st2 + '</a>';
 });
 
 function changeTabs(e) {
@@ -82,3 +73,12 @@ function changeTabs(e) {
     .removeAttribute("hidden");
 }
 
+///////////////////////////////////////
+// rotate images in images-rotate directory:
+var ind = getRandomInt(images_rotate.length); 
+var im = images_rotate[ind].image;
+st = '<img class="imrot-img" src="_static/images-rotate/' +im+'" />'
+var cap = images_rotate[ind].caption;
+var link = "https://matplotlib.org/stable/" + images_rotate[ind].link;
+st2 = '<div class="imrot-cap">'+ cap + '</div>'
+document.getElementById('image_rotator').innerHTML = '<a href="' + link + '"> ' + st + st2 + '</a>';


### PR DESCRIPTION
OK, @QuLogic suggested putting the image rotator in the ""DOMContentLoaded" section of `script.js`.  However, this does not appear to ever get loaded on gh-pages, so the image rotator was never run.  

