### PR TITLE
DOC: point cheatsheets to cheatsheets site versus github

### DIFF
--- a/docs/body.html
+++ b/docs/body.html
@@ -100,7 +100,7 @@
             </a>
           </li>
           <li>
-            <a href="https://github.com/matplotlib/cheatsheets#cheatsheets">
+            <a href="https://matplotlib.org/cheatsheets/">
               <img
                 src="_static/images/cheatsheets.png"
                 alt="cheatsheet icon"


### PR DESCRIPTION
Point the cheatsheet link to the site not the GitHub....