### PR TITLE
MNT: link fixes and copyedits...

### DIFF
--- a/docs/_templates/landing_footer.html
+++ b/docs/_templates/landing_footer.html
@@ -44,11 +44,11 @@
           >Code of Conduct</a
         >
       </li>
-      <li><a href="">License</a></li>
+      <li><a href="https://matplotlib.org/stable/users/project/license.html">License</a></li>
       <li>
         <a href="https://github.com/matplotlib/governance">Governance</a>
       </li>
-      <li><a href="">NumFOCUS Fiscally Sponsored Project</a></li>
+      <li><a href="https://numfocus.org/sponsored-projects">NumFOCUS Fiscally Sponsored Project</a></li>
     </ul>
 
     <ul class="release-docs grid__release-docs">

--- a/docs/body.html
+++ b/docs/body.html
@@ -69,7 +69,7 @@
         <ul class="quicklinks">
           <li>
             <a
-              href="https://matplotlib.org/devdocs/tutorials/introductory/usage.html#sphx-glr-tutorials-introductory-usage-py"
+              href="https://matplotlib.org/stable/tutorials/introductory/usage.html#sphx-glr-tutorials-introductory-usage-py"
             >
               <img
                 src="_static/images/getting-started.png"
@@ -80,7 +80,7 @@
             </a>
           </li>
           <li>
-            <a href="https://matplotlib.org/devdocs/plot_types/index.html">
+            <a href="https://matplotlib.org/stable/plot_types/index.html">
               <img
                 src="_static/images/sample-plots.png"
                 alt="folder icon"
@@ -90,7 +90,7 @@
             </a>
           </li>
           <li>
-            <a href="https://matplotlib.org/devdocs/index.html">
+            <a href="https://matplotlib.org/stable/index.html">
               <img
                 src="_static/images/userguide.png"
                 alt="documentation book icon"
@@ -110,7 +110,7 @@
             </a>
           </li>
           <li>
-            <a href="https://matplotlib.org/devdocs/contents.html">
+            <a href="https://matplotlib.org/stable/contents.html">
               <img
                 src="_static/images/documentation.png"
                 alt="matplotlib logo icon"
@@ -179,10 +179,10 @@
             <i class="far fa-question-circle callout__icon"></i>
             <p>
               Be sure to check the
-              <a href="https://matplotlib.org/devdocs/faq/index.html">FAQ</a>, the
-              <a href="https://matplotlib.org/devdocs/api/index.html">API docs</a
+              <a href="https://matplotlib.org/stable/faq/index.html">FAQ</a>, the
+              <a href="https://matplotlib.org/stable/api/index.html">API docs</a
               >. The full text
-              <a href="https://matplotlib.org/devdocs/search.html">search</a> is a
+              <a href="https://matplotlib.org/stable/search.html">search</a> is a
               good way to discover the docs including the many examples.
             </p>
           </div>
@@ -426,7 +426,7 @@
               <a href="https://github.com/matplotlib/matplotlib/issues"
                 >on GitHub</a
               >, or improving the
-              <a href="https://matplotlib.org/devdocs/devel/index.html"
+              <a href="https://matplotlib.org/stable/devel/index.html"
                 >documentation and code</a
               >!
             </p>
@@ -443,8 +443,8 @@
             <h4>Cite</h4>
             <p>
               Matplotlib is the result of development efforts by John Hunter
-              (1968&ndash;2012) and the projects
-              <a href="https://matplotlib.org/devdocs/users/credits.html"
+              (1968&ndash;2012) and the project's
+              <a href="https://matplotlib.org/stable/users/credits.html"
                 >many contributors.</a
               >
             </p>
@@ -453,7 +453,7 @@
               publication, please acknowledge this work by citing the project!
             </p>
             <a
-              href="https://matplotlib.org/devdocs/citing.html"
+              href="https://matplotlib.org/stable/citing.html"
               class="link--offsite"
               >Ready made citation</a
             >

--- a/docs/body.html
+++ b/docs/body.html
@@ -443,7 +443,7 @@
             <h4>Cite</h4>
             <p>
               Matplotlib is the result of development efforts by John Hunter
-              (1968&endash;2012) and the projects
+              (1968&ndash;2012) and the projects
               <a href="https://matplotlib.org/devdocs/users/credits.html"
                 >many contributors.</a
               >


### PR DESCRIPTION
- `endash->ndash`
- projects->projects's
- devdocs->stable
- filled in missing links in footer...