### PR TITLE
DOC: link getting started in users doc

### DIFF
--- a/docs/body.html
+++ b/docs/body.html
@@ -69,7 +69,7 @@
         <ul class="quicklinks">
           <li>
             <a
-              href="https://matplotlib.org/stable/tutorials/introductory/usage.html#sphx-glr-tutorials-introductory-usage-py"
+              href="https://matplotlib.org/stable/users/getting_started/"
             >
               <img
                 src="_static/images/getting-started.png"


### PR DESCRIPTION
Getting Started currently points to https://matplotlib.org/stable/tutorials/introductory/usage.html#sphx-glr-tutorials-introductory-usage-py  

This points it to: https://matplotlib.org/stable/users/getting_started/