### PR TITLE
Fix some homepage broken hyperlinks

### DIFF
--- a/docs/body.html
+++ b/docs/body.html
@@ -443,7 +443,7 @@
             <p>
               Matplotlib is the result of development efforts by John Hunter
               (1968&ndash;2012) and the project's
-              <a href="https://matplotlib.org/stable/users/credits.html"
+              <a href="https://matplotlib.org/stable/users/project/credits.html"
                 >many contributors.</a
               >
             </p>

--- a/docs/body.html
+++ b/docs/body.html
@@ -452,7 +452,7 @@
               publication, please acknowledge this work by citing the project!
             </p>
             <a
-              href="https://matplotlib.org/stable/citing.html"
+              href="https://matplotlib.org/stable/users/project/citing.html"
               class="link--offsite"
               >Ready made citation</a
             >


### PR DESCRIPTION
This pull request fixes 2 broken links on the home page:

https://matplotlib.org/stable/users/credits.html -> https://matplotlib.org/stable/users/project/credits.html
https://matplotlib.org/stable/citing.html -> https://matplotlib.org/stable/users/project/citing.html