### PR TITLE
Add a 404 page

### DIFF
--- a/docs/404.rst
+++ b/docs/404.rst
@@ -1,0 +1,11 @@
+:orphan:
+
+.. title:: Page Not Found
+
+.. raw:: html
+
+  <section class="grid__full-page">
+    <h1>Page Not Found</h1>
+
+    <p>Unfortunately we couldn't find the content you were looking for.</p>
+  </section>

--- a/docs/_static/css/landing.css
+++ b/docs/_static/css/landing.css
@@ -409,7 +409,20 @@ ul.mpl-links {
 }
 
 /* layout */
+html, body {
+    width: 100%;
+    height: 100%;
+}
+
+.document {
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+}
+
 main {
+  flex-grow: 1;
   display: grid;
   column-gap: 20px;
 }
@@ -458,6 +471,10 @@ main {
       ". support ."
       "footer footer footer";
   }
+}
+
+.grid__full-page {
+  grid-area: intro-start / intro-start / footer-start / intro-text-end;
 }
 
 .grid__intro-text {

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -34,6 +34,7 @@
 
 {% block body_tag %}
   <body data-spy="scroll" data-target="#bd-toc-nav" data-offset="80">
+    <div class="document">
 {%- endblock %}
 {%- block content %}
     {# Added to support a banner with an alert #}
@@ -56,4 +57,6 @@
 
 {%- block footer %}
 {%- include "landing_footer.html" %}
+  {# Closes the div added in body_tag above. #}
+  </div>
 {%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,9 @@ author = "Matplotlib Developers"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = [
+    'notfound.extension',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 
@@ -40,3 +42,6 @@ html_theme_options = {
 # relative to this directory. They are copied after the theme static files,
 # so a file named "default.css" will overwrite the theme's "default.css".
 html_static_path = ["_static"]
+
+# Prefix added to all the URLs generated in the 404 page.
+notfound_urls_prefix = '/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-sphinx
-mpl-sphinx-theme
 jinja2>3
+mpl-sphinx-theme
+sphinx
+sphinx-notfound-page


### PR DESCRIPTION
On the new server, there is no default 404 page, which results in an empty document if navigating to an invalid URL. This generates a 404 page using our page CSS, so that it fits into the rest of the site better.

This also tweaks the layout so that the footer is forced to the bottom even for small pages (like the 404 page).