### PR TITLE
BLD: remove inventory file

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,8 @@ jobs:
         run: pip install -r requirements.txt
       - name: Build
         run: make -Cdocs html
+      - name: remove inventory
+        run: rm ./docs/_build/html/objects.inv
       - name: Publish
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
xref to https://github.com/matplotlib/matplotlib/issues/22601

Due to the way that we publish the docs now any files from
matplotilb.github.com including the re-direct to the stable inventory.

This has broken users.