### PR TITLE
Inherit layout template from pydata-sphinx-theme

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,36 +1,6 @@
 <!-- from pydata-sphinx-theme to simplify for landing page -->
-{%- extends "basic/layout.html" %}
+{%- extends "pydata_sphinx_theme/layout.html" %}
 {%- import "static/webpack-macros.html" as _webpack with context %}
-
-{%- block css %}
-    {{ _webpack.head_pre_bootstrap() }}
-    {{ _webpack.head_pre_icons() }}
-    {% block fonts %}
-      {{ _webpack.head_pre_fonts() }}
-    {% endblock %}
-    {{- css() }}
-{%- endblock %}
-
-{%- block extrahead %}
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="docsearch:language" content="{{ language }}">
-    {% for favicon in theme_favicons %}
-      {% if favicon.href[:4] == 'http'%}
-      <link rel="{{ favicon.rel }}" sizes="{{ favicon.sizes }}" href="{{ favicon.href }}">
-      {% else %}
-      <link rel="{{ favicon.rel }}" sizes="{{ favicon.sizes }}" href="{{ pathto('_static/' + favicon.href, 1) }}">
-      {% endif %}
-    {% endfor %}
-
-    <!-- Google Analytics -->
-    {{ generate_google_analytics_script(id=theme_google_analytics_id) }}
-{%- endblock %}
-
-{# Silence the sidebar's, relbar's #}
-{% block header %}{% endblock %}
-{% block relbar1 %}{% endblock %}
-{% block relbar2 %}{% endblock %}
-{% block sidebarsourcelink %}{% endblock %}
 
 {% block body_tag %}
   <body data-spy="scroll" data-target="#bd-toc-nav" data-offset="80">
@@ -40,19 +10,12 @@
     {# Added to support a banner with an alert #}
     <div class="container-fluid" id="banner"></div>
 
-    {% block docs_navbar %}
-    <nav class="navbar navbar-light navbar-expand-lg bg-light fixed-top bd-navbar" id="navbar-main">
-      {%- include "docs-navbar.html" %}
-    </nav>
-    {% endblock %}
+    {% block docs_navbar %}{{ super() }}{% endblock %}
     <main role="main">
       {% block body %} {% endblock %}
     </main>
 
-  {%- block scripts_end %}
-  {{ _webpack.body_post() }}
-  {%- endblock %}
-
+  {%- block scripts_end %}{{ super() }}{%- endblock %}
 {%- endblock %}
 
 {%- block footer %}


### PR DESCRIPTION
Instead of using the base layer theme, inherit from pydata, which means we don't need to copy all of it, and will break less.

This fixes compatibility with pydata-sphinx-theme 0.8.1 without losing compatibility with older versions.