### PR TITLE
Added meeting calendar under resources

### DIFF
--- a/docs/body.html
+++ b/docs/body.html
@@ -223,7 +223,7 @@
           </div>
 
           <div class="callout__list">
-            <i class="fa fa-solid fa-calendar-alt" aria-hidden="true"></i>
+            <i class="fa fa-solid fa-calendar-alt callout__icon" aria-hidden="true"></i>
             <p>
               Meet us at our monthly call for new contributors to the Matplotlib project. Subscribe to our
               <a href="https://scientific-python.org/calendars/">community calendar</a> 

--- a/docs/body.html
+++ b/docs/body.html
@@ -213,21 +213,30 @@
           </div>
 
           <div class="callout__list">
-            <i class="fab fa-gitter callout__icon" aria-hidden="true"></i>
-            <p>
-              Short questions may be posted on the
-              <a href="https://gitter.im/matplotlib/matplotlib">gitter</a>
-              channel.
-            </p>
-          </div>
-
-          <div class="callout__list">
             <i class="fab fa-stack-overflow callout__icon" aria-hidden="true"></i>
             <p>
               Check out the Matplotlib tag on
               <a href="https://stackoverflow.com/questions/tagged/matplotlib"
                 >StackOverflow</a
               >.
+            </p>
+          </div>
+
+          <div class="callout__list">
+            <i class="fab fa-solid fa-calendar-days"aria-hidden="true"></i>
+            <p>
+              Meet us at our monthly call for new contributors to the Matplotlib project. Subscribe to our
+              <a href="https://scientific-python.org/calendars/">community calendar</a> 
+              at Scientific Python to get acces to all our community meetings.
+            </p>
+          </div>
+
+          <div class="callout__list">
+            <i class="fab fa-gitter callout__icon" aria-hidden="true"></i>
+            <p>
+              Short questions related to contributing to Matplotlib may be posted on the
+              <a href="https://gitter.im/matplotlib/matplotlib">gitter</a>
+              channel.
             </p>
           </div>
         <!-- </div> -->

--- a/docs/body.html
+++ b/docs/body.html
@@ -223,7 +223,7 @@
           </div>
 
           <div class="callout__list">
-            <i class="fab fa-solid fa-calendar-days"aria-hidden="true"></i>
+            <i class="fa fa-solid fa-calendar-alt" aria-hidden="true"></i>
             <p>
               Meet us at our monthly call for new contributors to the Matplotlib project. Subscribe to our
               <a href="https://scientific-python.org/calendars/">community calendar</a> 


### PR DESCRIPTION
👋  
1. I added the meeting calendar under resources, highlighting the new contributor meeting. 
2. I wasn't able to preview the CSS locally so please let me know if I added the `fa-icon` correctly or not.
3. I also tweaked the text for Gitter to be more inline with what we have in the README on github. Let me know if you'd like me to revert that.
4. I put those to together. I thought the order made sense because the first 3 are for all project users, and the last 2 are relevant for those interested specifically in contributing to the project.

