### PR TITLE
MNT: pin the theme until 3.6 is released

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
-pydata-sphinx-theme>=0.6.0
+pydata-sphinx-theme<0.9.0
+sphinx-notfound-page

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-pydata-sphinx-theme<0.9.0
-sphinx-notfound-page

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jinja2>3
+pydata-sphinx-theme<0.9.0
 mpl-sphinx-theme
 sphinx
 sphinx-notfound-page


### PR DESCRIPTION
The 3.5 release and any changes should be pinned to the pydata-sphinx-theme we were using then.  