### PR TITLE
Fix some typos

### DIFF
--- a/docs/_templates/landing_footer.html
+++ b/docs/_templates/landing_footer.html
@@ -3,7 +3,7 @@
       <h1>Matplotlib</h1>
       <ul class="social fas">
         <li>
-          <a href="https://github.com/matplotlib/matplotlib" aria-label="Matplotlib on Github">
+          <a href="https://github.com/matplotlib/matplotlib" aria-label="Matplotlib on GitHub">
             <i class="fab fa-github" aria-hidden="true"></i>
           </a>
         </li>
@@ -22,7 +22,7 @@
             <i class="fab fa-gitter" aria-hidden="true"></i>
           </a>
         </li>
-        <li class="social__instagran">
+        <li class="social__instagram">
           <a href="https://instagram.com/matplotart" aria-label="Matplotlib on Instagram">
             <i class="fab fa-instagram" aria-hidden="true"></i>
           </a>
@@ -31,8 +31,7 @@
       <a
         href="https://numfocus.org/donate-to-matplotlib"
         class="button button--green"
-        >Donate to Matplotlib</a
-      >
+        >Donate to Matplotlib</a>
 
       <p class="copywrite">©2021 The Matplotlib Development team</p>
     </div>
@@ -42,8 +41,7 @@
       <li>
         <a
           href="https://github.com/matplotlib/matplotlib/blob/master/CODE_OF_CONDUCT.md"
-          >Code of Conduct</a
-        >
+          >Code of Conduct</a>
       </li>
       <li><a href="https://matplotlib.org/stable/users/project/license.html">License</a></li>
       <li>
@@ -58,8 +56,7 @@
         <dd>
           <a href="https://matplotlib.org/stable">docs</a> |
           <a href="https://matplotlib.org/stable/users/whats_new.html"
-            >changelog</a
-          >
+            >changelog</a>
         </dd>
       </dl>
 

--- a/docs/_templates/landing_footer.html
+++ b/docs/_templates/landing_footer.html
@@ -1,70 +1,76 @@
 <footer class="footer-section">
-    <div class="grid__mpl-info">
-      <h1>Matplotlib</h1>
-      <ul class="social fas">
-        <li>
-          <a href="https://github.com/matplotlib/matplotlib" aria-label="Matplotlib on GitHub">
-            <i class="fab fa-github" aria-hidden="true"></i>
-          </a>
-        </li>
-        <li class="social__twitter">
-          <a href="https://twitter.com/matplotlib" aria-label="Matplotlib on Twitter">
-            <i class="fab fa-twitter" aria-hidden="true"></i>
-          </a>
-        </li>
-        <li class="social__discourse">
-          <a href="https://discourse.matplotlib.org" aria-label="Matplotlib Discourse">
-            <i class="fab fa-discourse" aria-hidden="true"></i>
-          </a>
-        </li>
-        <li class="social__gitter">
-          <a href="https://gitter.im/matplotlib/matplotlib" aria-label="Matplotlib on Gitter">
-            <i class="fab fa-gitter" aria-hidden="true"></i>
-          </a>
-        </li>
-        <li class="social__instagram">
-          <a href="https://instagram.com/matplotart" aria-label="Matplotlib on Instagram">
-            <i class="fab fa-instagram" aria-hidden="true"></i>
-          </a>
-        </li>
-      </ul>
+  <div class="grid__mpl-info">
+    <h1>Matplotlib</h1>
+    <ul class="social fas">
+      <li>
+        <a href="https://github.com/matplotlib/matplotlib" aria-label="Matplotlib on GitHub">
+          <i class="fab fa-github" aria-hidden="true"></i>
+        </a>
+      </li>
+      <li class="social__twitter">
+        <a href="https://twitter.com/matplotlib" aria-label="Matplotlib on Twitter">
+          <i class="fab fa-twitter" aria-hidden="true"></i>
+        </a>
+      </li>
+      <li class="social__discourse">
+        <a href="https://discourse.matplotlib.org" aria-label="Matplotlib Discourse">
+          <i class="fab fa-discourse" aria-hidden="true"></i>
+        </a>
+      </li>
+      <li class="social__gitter">
+        <a href="https://gitter.im/matplotlib/matplotlib" aria-label="Matplotlib on Gitter">
+          <i class="fab fa-gitter" aria-hidden="true"></i>
+        </a>
+      </li>
+      <li class="social__instagram">
+        <a href="https://instagram.com/matplotart" aria-label="Matplotlib on Instagram">
+          <i class="fab fa-instagram" aria-hidden="true"></i>
+        </a>
+      </li>
+    </ul>
+    <a
+      href="https://numfocus.org/donate-to-matplotlib"
+      class="button button--green"
+      >Donate to Matplotlib</a>
+
+    <p class="copywrite">©2021 The Matplotlib Development team</p>
+  </div>
+
+  <ul class="mpl-links grid__mpl-links">
+    <li><a href="https://matplotlib.org/matplotblog/">Matplotblog</a></li>
+    <li>
       <a
-        href="https://numfocus.org/donate-to-matplotlib"
-        class="button button--green"
-        >Donate to Matplotlib</a>
+        href="https://github.com/matplotlib/matplotlib/blob/master/CODE_OF_CONDUCT.md"
+        >Code of Conduct</a>
+    </li>
+    <li>
+      <a href="https://matplotlib.org/stable/users/project/license.html"
+        >License</a>
+    </li>
+    <li>
+      <a href="https://matplotlib.org/governance/">Governance</a>
+    </li>
+    <li>
+      <a href="https://numfocus.org/sponsored-projects"
+        >NumFOCUS Fiscally Sponsored Project</a>
+    </li>
+  </ul>
 
-      <p class="copywrite">©2021 The Matplotlib Development team</p>
-    </div>
+  <ul class="release-docs grid__release-docs">
+    <dl class="release">
+      <dt>Latest Stable Release</dt>
+      <dd>
+        <a href="https://matplotlib.org/stable">docs</a> |
+        <a href="https://matplotlib.org/stable/users/whats_new.html"
+          >changelog</a>
+      </dd>
+    </dl>
 
-    <ul class="mpl-links grid__mpl-links">
-      <li><a href="https://matplotlib.org/matplotblog/">Matplotblog</a></li>
-      <li>
-        <a
-          href="https://github.com/matplotlib/matplotlib/blob/master/CODE_OF_CONDUCT.md"
-          >Code of Conduct</a>
-      </li>
-      <li><a href="https://matplotlib.org/stable/users/project/license.html">License</a></li>
-      <li>
-        <a href="https://matplotlib.org/governance/">Governance</a>
-      </li>
-      <li><a href="https://numfocus.org/sponsored-projects">NumFOCUS Fiscally Sponsored Project</a></li>
-    </ul>
-
-    <ul class="release-docs grid__release-docs">
-      <dl class="release">
-        <dt>Latest Stable Release</dt>
-        <dd>
-          <a href="https://matplotlib.org/stable">docs</a> |
-          <a href="https://matplotlib.org/stable/users/whats_new.html"
-            >changelog</a>
-        </dd>
-      </dl>
-
-      <dl class="release">
-        <dt>Development version</dt>
-        <dd>
-          <a href="https://matplotlib.org/devdocs/index.html">docs</a>
-        </dd>
-      </dl>
-    </ul>
+    <dl class="release">
+      <dt>Development version</dt>
+      <dd>
+        <a href="https://matplotlib.org/devdocs/index.html">docs</a>
+      </dd>
+    </dl>
+  </ul>
 </footer>

--- a/docs/body.html
+++ b/docs/body.html
@@ -10,16 +10,13 @@
           <li>
             Create
             <a href="https://ieeexplore.ieee.org/document/4160265/citations?tabFilter=papers"
-              >publication quality plots</a
-            >.
+              >publication quality plots</a>.
           </li>
           <li>
             Make
             <a
               href="https://mybinder.org/v2/gh/matplotlib/mpl-brochure-binder/main?labpath=MatplotlibExample.ipynb"
-              >interactive figures</a
-            >
-            that can zoom, pan, update.
+              >interactive figures</a> that can zoom, pan, update.
           </li>
           <li>
             Customize
@@ -32,23 +29,18 @@
           <li>
             Export to
             <a href="https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure.savefig"
-              >many file formats</a
-            >
-            .
+              >many file formats</a>.
           </li>
           <li>
             Embed in
             <a href="https://matplotlib.org/stable/gallery/#embedding-matplotlib-in-graphical-user-interfaces"
-              >JupyterLab and Graphical User Interfaces</a
-            >.
+              >JupyterLab and Graphical User Interfaces</a>.
           </li>
           <li>
             Use a rich array of
             <a href="https://matplotlib.org/mpl-third-party/"
-              >third-party packages</a
-            >
+              >third-party packages</a>
             built on Matplotlib.
-
           </li>
         </ul>
 
@@ -58,8 +50,7 @@
           tabindex="0"
           role="button"
         >
-          Try Matplotlib (on Binder)
-        </a>
+          Try Matplotlib (on Binder)</a>
       </section>
       <section class="grid__intro" id="image_rotator"></section>
       <!-- END INTRO SECTION -->
@@ -68,9 +59,7 @@
       <section class="grid__quicklinks">
         <ul class="quicklinks">
           <li>
-            <a
-              href="https://matplotlib.org/stable/users/getting_started/"
-            >
+            <a href="https://matplotlib.org/stable/users/getting_started/">
               <img
                 src="_static/images/getting-started.png"
                 alt="computer desktop icon"
@@ -147,7 +136,7 @@
 
               See <a href="https://discourse.matplotlib.org/t/research-software-engineer-roses-2020-position/22597">the job description on discourse</a> and
               submit an application
-              via <a href='https://numfocus.typeform.com/to/tYdJ2vWr'>TypeForm</a>.
+              via <a href="https://numfocus.typeform.com/to/tYdJ2vWr">TypeForm</a>.
             </p>
           </div>
 
@@ -167,25 +156,20 @@
             <a href="https://discourse.matplotlib.org/t/matplotlib-awarded-czi-eoss-grant-cycle-4/22300" class="link--offsite">Matplotlib awarded a CZI EOSS Cycle 4 grant</a>
           </div>
 
-        <!-- END NEWS ITEMS -->
-        <!-- link to discourse -->
-        <div class="news__discourse-link">
-          <div class="rule"></div>
-          <a
-            href="https://discourse.matplotlib.org/c/announce/14"
-            class="link--offsite"
-            >Older Announcements</a
-          >
+          <!-- END NEWS ITEMS -->
+          <!-- link to discourse -->
+          <div class="news__discourse-link">
+            <div class="rule"></div>
+            <a
+              href="https://discourse.matplotlib.org/c/announce/14"
+              class="link--offsite">Older Announcements</a>
+          </div>
         </div>
       </section>
 
-
       <!-- START RESOURCES -->
       <section class="grid__resources">
-
-
         <!-- drop boxes !-->
-        <!-- <div class="callout callout--blue"> -->
           <h3>Resources</h3>
           <div class="callout__list">
             <i class="far fa-question-circle callout__icon"></i>
@@ -204,9 +188,7 @@
             <i class="fab fa-discourse callout__icon" aria-hidden="true"></i>
             <p>
               Join our community at
-              <a href="https://discourse.matplotlib.org">
-                discourse.matplotlib.org
-              </a>
+              <a href="https://discourse.matplotlib.org">discourse.matplotlib.org</a>
               to get help, share your work, and discuss contributing &amp;
               development.
             </p>
@@ -227,7 +209,7 @@
             <p>
               Meet us at our monthly call for new contributors to the Matplotlib project. Subscribe to our
               <a href="https://scientific-python.org/calendars/">community calendar</a> 
-              at Scientific Python to get acces to all our community meetings.
+              at Scientific Python to get access to all our community meetings.
             </p>
           </div>
 
@@ -239,7 +221,6 @@
               channel.
             </p>
           </div>
-        <!-- </div> -->
       </section>
       <!-- END RESOURCES -->
 
@@ -331,8 +312,7 @@
               exploring and understanding complex datasets.
             </p>
             <a href="https://seaborn.pydata.org/" class="link--offsite"
-              >statistical data visualization</a
-            >
+              >statistical data visualization</a>
           </div>
           <img src="" alt="" />
         </div>
@@ -355,8 +335,7 @@
             <a
               href="https://scitools.org.uk/cartopy/docs/latest/"
               class="link--offsite"
-              >Cartopy</a
-            >
+              >Cartopy</a>
           </div>
           <img src="" alt="" />
         </div>
@@ -377,8 +356,7 @@
             <a
               href="https://github.com/Edinburgh-Genome-Foundry/DnaFeaturesViewer"
               class="link--offsite"
-              >DNA Features Viewer</a
-            >
+              >DNA Features Viewer</a>
           </div>
           <img src="" alt="" />
         </div>
@@ -400,8 +378,7 @@
             <a
               href="https://plotnine.readthedocs.io/en/stable/"
               class="link--offsite"
-              >plotnine</a
-            >
+              >plotnine</a>
           </div>
           <img src="" alt="" />
         </div>
@@ -422,8 +399,7 @@
             <a
               href="https://docs.astropy.org/en/stable/visualization/wcsaxes/"
               class="link--offsite"
-              >WCSAxes</a
-            >
+              >WCSAxes</a>
           </div>
           <img src="" alt="" />
         </div>
@@ -449,17 +425,14 @@
                 >on GitHub</a
               >, or improving the
               <a href="https://matplotlib.org/stable/devel/index.html"
-                >documentation and code</a
-              >!
+                >documentation and code</a>!
             </p>
             <a href="https://discourse.matplotlib.org" class="link--offsite"
-              >Join us on Discourse</a
-            >
+              >Join us on Discourse</a>
             <a
               href="https://github.com/matplotlib/matplotlib"
               class="link--offsite"
-              >Join us on GitHub</a
-            >
+              >Join us on GitHub</a>
           </li>
           <li class="callout callout--blue">
             <h4>Cite</h4>
@@ -467,8 +440,7 @@
               Matplotlib is the result of development efforts by John Hunter
               (1968&ndash;2012) and the project's
               <a href="https://matplotlib.org/stable/users/project/credits.html"
-                >many contributors.</a
-              >
+                >many contributors</a>.
             </p>
             <p>
               If Matplotlib contributes to a project that leads to a scientific
@@ -477,8 +449,7 @@
             <a
               href="https://matplotlib.org/stable/users/project/citing.html"
               class="link--offsite"
-              >Ready made citation</a
-            >
+              >Ready made citation</a>
           </li>
           <li class="callout callout--teal">
             <h4>Donate</h4>
@@ -486,23 +457,19 @@
               If you would like to support Matplotlib financially you can
               donate by
               <a href="https://github.com/sponsors/matplotlib">
-                sponsoring Matplotlib on GitHub
-              </a>
+                sponsoring Matplotlib on GitHub</a>
               or making a (USA) tax-deductible donation
               <a href="https://numfocus.org/donate-to-matplotlib">
-                through NumFOCUS
-              </a>.
+                through NumFOCUS</a>.
             </p>
             <a
               href="https://github.com/sponsors/matplotlib"
               class="link--offsite"
-              >Sponsor on GitHub</a
-            >
+              >Sponsor on GitHub</a>
             <a
               href="https://numfocus.org/donate-to-matplotlib"
               class="link--offsite"
-              >Donate to Matplotlib</a
-            >
+              >Donate to Matplotlib</a>
           </li>
         </ul>
       </section>

--- a/docs/body.html
+++ b/docs/body.html
@@ -170,57 +170,57 @@
       <!-- START RESOURCES -->
       <section class="grid__resources">
         <!-- drop boxes !-->
-          <h3>Resources</h3>
-          <div class="callout__list">
-            <i class="far fa-question-circle callout__icon"></i>
-            <p>
-              Be sure to check the
-              <a href="https://matplotlib.org/stable/users/index.html">Users
-              guide</a> and the
-              <a href="https://matplotlib.org/stable/api/index.html">API docs</a
-              >. The full text
-              <a href="https://matplotlib.org/stable/search.html">search</a> is a
-              good way to discover the docs including the many examples.
-            </p>
-          </div>
+        <h3>Resources</h3>
+        <div class="callout__list">
+          <i class="far fa-question-circle callout__icon"></i>
+          <p>
+            Be sure to check the
+            <a href="https://matplotlib.org/stable/users/index.html">Users
+            guide</a> and the
+            <a href="https://matplotlib.org/stable/api/index.html">API
+            docs</a>. The full text
+            <a href="https://matplotlib.org/stable/search.html">search</a> is a
+            good way to discover the docs including the many examples.
+          </p>
+        </div>
 
-          <div class="callout__list">
-            <i class="fab fa-discourse callout__icon" aria-hidden="true"></i>
-            <p>
-              Join our community at
-              <a href="https://discourse.matplotlib.org">discourse.matplotlib.org</a>
-              to get help, share your work, and discuss contributing &amp;
-              development.
-            </p>
-          </div>
+        <div class="callout__list">
+          <i class="fab fa-discourse callout__icon" aria-hidden="true"></i>
+          <p>
+            Join our community at
+            <a href="https://discourse.matplotlib.org">discourse.matplotlib.org</a>
+            to get help, share your work, and discuss contributing &amp;
+            development.
+          </p>
+        </div>
 
-          <div class="callout__list">
-            <i class="fab fa-stack-overflow callout__icon" aria-hidden="true"></i>
-            <p>
-              Check out the Matplotlib tag on
-              <a href="https://stackoverflow.com/questions/tagged/matplotlib"
-                >StackOverflow</a
-              >.
-            </p>
-          </div>
+        <div class="callout__list">
+          <i class="fab fa-stack-overflow callout__icon" aria-hidden="true"></i>
+          <p>
+            Check out the Matplotlib tag on
+            <a href="https://stackoverflow.com/questions/tagged/matplotlib"
+              >StackOverflow</a>.
+          </p>
+        </div>
 
-          <div class="callout__list">
-            <i class="fa fa-solid fa-calendar-alt callout__icon" aria-hidden="true"></i>
-            <p>
-              Meet us at our monthly call for new contributors to the Matplotlib project. Subscribe to our
-              <a href="https://scientific-python.org/calendars/">community calendar</a> 
-              at Scientific Python to get access to all our community meetings.
-            </p>
-          </div>
+        <div class="callout__list">
+          <i class="fa fa-solid fa-calendar-alt callout__icon" aria-hidden="true"></i>
+          <p>
+            Meet us at our monthly call for new contributors to the Matplotlib
+            project. Subscribe to our
+            <a href="https://scientific-python.org/calendars/">community calendar</a>
+            at Scientific Python to get access to all our community meetings.
+          </p>
+        </div>
 
-          <div class="callout__list">
-            <i class="fab fa-gitter callout__icon" aria-hidden="true"></i>
-            <p>
-              Short questions related to contributing to Matplotlib may be posted on the
-              <a href="https://gitter.im/matplotlib/matplotlib">gitter</a>
-              channel.
-            </p>
-          </div>
+        <div class="callout__list">
+          <i class="fab fa-gitter callout__icon" aria-hidden="true"></i>
+          <p>
+            Short questions related to contributing to Matplotlib may be posted on the
+            <a href="https://gitter.im/matplotlib/matplotlib">gitter</a>
+            channel.
+          </p>
+        </div>
       </section>
       <!-- END RESOURCES -->
 


### PR DESCRIPTION
- extra spaces within links before the next punctuation mark
- a missing `</div>`
- a single-quoted string instead of double quotes
- acces -> access

Additionally, dedents the Resources section the extra one level.