### PR TITLE
update blog link

### DIFF
--- a/docs/_templates/landing_footer.html
+++ b/docs/_templates/landing_footer.html
@@ -37,7 +37,7 @@
   </div>
 
   <ul class="mpl-links grid__mpl-links">
-    <li><a href="https://matplotlib.org/matplotblog/">Matplotblog</a></li>
+    <li><a href="https://blog.scientific-python.org/tags/matplotlib/">Matplotblog</a></li>
     <li>
       <a
         href="https://github.com/matplotlib/matplotlib/blob/master/CODE_OF_CONDUCT.md"


### PR DESCRIPTION
Changed it to the scientific python blog since we no longer maintain it; alternatively it could be removed?