### PR TITLE
Fix sidebar buttons on mobile

### DIFF
--- a/docs/_static/css/landing.css
+++ b/docs/_static/css/landing.css
@@ -437,14 +437,21 @@ html, body {
     align-items: stretch;
 }
 
-main {
+@media (min-width: 960px) {
+  /* Undo pydata-sphinx-theme's max width setting. */
+  div.bd-container__inner.bd-page-width {
+    max-width: inherit;
+  }
+}
+
+main.bd-main {
   flex-grow: 1;
   display: grid;
   column-gap: 20px;
 }
 
 @media (min-width: 800px) {
-  main {
+  main.bd-main {
     grid-template-columns:
       minmax(1em, auto) repeat(12, minmax(44px, 118px)) minmax(1em, auto);
     grid-template-areas:
@@ -463,7 +470,7 @@ main {
 }
 
 @media (max-width: 799px) {
-  main {
+  main.bd-main {
     margin-top: 0px;
     grid-template-columns: 1em auto 1em;
     grid-template-areas:

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -6,35 +6,9 @@
   {{- super() }}
   <div class="document">
 {%- endblock %}
-{%- block content %}
-  {# checkbox to toggle primary sidebar #}
-  <input type="checkbox" class="sidebar-toggle" name="__primary" id="__primary">
-  <label class="overlay overlay-primary" for="__primary"></label>
 
-  {# Checkboxes to toggle the secondary sidebar #}
-  <input type="checkbox" class="sidebar-toggle" name="__secondary" id="__secondary">
-  <label class="overlay overlay-secondary" for="__secondary"></label>
-
-  {# A search field pop-up that will only show when the search button is clicked #}
-  <div class="search-button__wrapper">
-    <div class="search-button__overlay"></div>
-    <div class="search-button__search-container">
-      {% include "../components/search-field.html" %}
-    </div>
-  </div>
-
-  {%- if theme_announcement -%}
-  <div class="bd-header-announcement container-fluid" id="header-announcement">
-    {% include "sections/announcement.html" %}
-  </div>
-  {%- endif %}
-
-  {% block docs_navbar %}{{ super() }}{% endblock %}
-  <main role="main">
-    {% block body %} {% endblock %}
-  </main>
-
-  {%- block scripts_end %}{{ super() }}{%- endblock %}
+{%- block docs_main %}
+  {% block body %} {% endblock %}
 {%- endblock %}
 
 {%- block footer %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ html_theme_options = {
     },
     "navbar_links": "server-stable",
     "footer_items": ["landing_footer"],
+    "page_sidebar_items": [],
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Disable the right button since we have no sidebar there.

Then simplify our theme override so that we get all of the stuff from the theme, i.e., the search, sidebar, and scripts, without having to copy them ourselves.