### PR TITLE
added anchors 

### DIFF
--- a/docs/body.html
+++ b/docs/body.html
@@ -115,11 +115,11 @@
       <div class="rule rule--viridis grid__rule1"></div>
 
       <!-- News -->
-      <section class="grid__news news">
+      <section class="grid__news news" id="news">
         <div class="news__items">
           <!-- make these easier to visually differentiate !-->
           <!-- optional important news -->
-          <h3>News</h3>
+          <h3>News<a class="headerlink" href="#news" title="Permalink to news section">#</a></h3>
           <div class="news__item--highlight">
             <h5 class="date">November 23, 2022</h5>
             <a href="https://discourse.matplotlib.org/t/nasa-rose-rse-hired/23334" class="link--offsite">Sunden hired as Research Software Engineer</a>
@@ -160,9 +160,9 @@
       </section>
 
       <!-- START RESOURCES -->
-      <section class="grid__resources">
+      <section class="grid__resources" id="resources">
         <!-- drop boxes !-->
-        <h3>Resources</h3>
+        <h3>Resources<a class ="headerlink" href="#resources" title="Permalink to resources section">#</a></h3>
         <div class="callout__list">
           <i class="far fa-question-circle callout__icon"></i>
           <p>
@@ -216,10 +216,10 @@
       </section>
       <!-- END RESOURCES -->
 
-      <div class="rule rule--viridis grid__rule2"></div>
+      <div class="rule rule--viridis grid__rule2" id="domain-specific-tools"></div>
       <!-- START DOMAIN SPECIFIC TOOLS -->
       <section class="grid__tools">
-        <h3>Domain Specific Tools</h3>
+        <h3>Domain Specific Tools<a class="headerlink" href="#domain-specific-tools" title="Permalink to domain specific tools section">#</a></h3>
         <p>
           A large number of third party packages extend and build on Matplotlib
           functionality, including several higher-level plotting interfaces
@@ -401,8 +401,8 @@
       <div class="rule rule--viridis grid__rule3"></div>
 
       <!-- START SUPPORT MATPLOTLIB -->
-      <section class="grid__support">
-        <h2>Support Matplotlib</h2>
+      <section class="grid__support" id="support">
+        <h2>Support Matplotlib<a class="headerlink" href="#support" title="Permalink to support Matplotlib section">#</a></h2>
         <ul class="support__items grid__contribute">
           <li class="callout callout--purple">
             <h4>Contribute</h4>


### PR DESCRIPTION
I turned the news, resources, domain-specific-tools, and support headers into anchors/links so that I could link to those specific sections. This was motivated by wanting to provide a link to the list of resources on the homepage. 