### PR TITLE
Fix year of 3.7.0 release date

### DIFF
--- a/docs/body.html
+++ b/docs/body.html
@@ -121,7 +121,7 @@
           <!-- optional important news -->
           <h3>News<a class="headerlink" href="#news" title="Permalink to news section">#</a></h3>
           <div class="news__item--highlight">
-            <h5 class="date">Feburary 14, 2022</h5>
+            <h5 class="date">Feburary 14, 2023</h5>
             <a href="https://discourse.matplotlib.org/t/matplotlib-devel-ann-matplotlib-3-7-0/23568" class="link--offsite">Matplotlib 3.7.0 Released</a>
             <p>
               We thank the 112 authors for the 427 pull requests that comprise the 3.7.0 release.


### PR DESCRIPTION
Hello,
I just noticed a typo on https://matplotlib.org/ front page with regard to the year of release of mpl 3.7.
2022 → 2023