### PR TITLE
Remove extra offsite CSS from news links

### DIFF
--- a/docs/body.html
+++ b/docs/body.html
@@ -124,14 +124,16 @@
             <h5 class="date">May 30, 2023</h5>
             <a href="https://discourse.matplotlib.org/t/gsoc-contributor-chosen/23850" class="link--offsite">Ratnabali Dutta chosen as GSOC contributor</a>
             <p>  
-              Thanks to the Google Summer of Code (GSOC) program, Ratnabali Dutta joins us this summer to work on improving our mathematical typesetting module <a href="https://matplotlib.org/stable/tutorials/text/mathtext.html" class="link--offsite">MathTex</a>.
+              Thanks to the Google Summer of Code (GSOC) program, Ratnabali Dutta joins us this summer to work on improving our mathematical typesetting module <a href="https://matplotlib.org/stable/tutorials/text/mathtext.html">MathTex</a>.
             </p>
           </div>
 
           <div class="news__item">
             <h5 class="date">May 18, 2023</h5>
             <a href="https://discourse.matplotlib.org/t/gsod-writer-hired/23796" class="link--offsite">Eva Sibinga hired as GSOD Technical Writer</a>
-            <p> Thanks to funding from the Google Season of Docs (GSOD) program, Eva Sibinga will be joining us to work on <a href="https://github.com/matplotlib/matplotlib/wiki/Google-Season-of-Docs-2023:-Proposal" class="link--offsite">cataloguing our gallery</a>. </p>
+            <p>
+              Thanks to funding from the Google Season of Docs (GSOD) program, Eva Sibinga will be joining us to work on <a href="https://github.com/matplotlib/matplotlib/wiki/Google-Season-of-Docs-2023:-Proposal">cataloguing our gallery</a>.
+            </p>
           </div>
           <div class="news__item">
             <h5 class="date">May 5, 2023</h5>


### PR DESCRIPTION
These cause extra arrows to be added in the middle of the news text.
![image](https://github.com/matplotlib/mpl-brochure-site/assets/302469/dda29e4d-77a8-406c-8fea-5625b7f5f9ea)
Note how the link is on its own line and the sentence period is by itself after.