### PR TITLE
LINK: update coc to point to docs

### DIFF
--- a/docs/_templates/landing_footer.html
+++ b/docs/_templates/landing_footer.html
@@ -40,7 +40,7 @@
     <li><a href="https://blog.scientific-python.org/tags/matplotlib/">Matplotblog</a></li>
     <li>
       <a
-        href="https://github.com/matplotlib/matplotlib/blob/master/CODE_OF_CONDUCT.md"
+        href="https://matplotlib.org/stable/users/project/code_of_conduct.html"
         >Code of Conduct</a>
     </li>
     <li>


### PR DESCRIPTION
Since the coc is now in the docs, the footer may as well point there https://matplotlib.org/stable/users/project/code_of_conduct.html

Matches the next link down which goes to its neighbor.