### PR TITLE
DOC: made contribute guide link more prominant

### DIFF
--- a/docs/body.html
+++ b/docs/body.html
@@ -410,16 +410,14 @@
           <li class="callout callout--purple">
             <h4>Contribute</h4>
             <p>
-              Matplotlib is a community project maintained for and by its users
-            </p>
-            <p>
-              You can help by answering questions
+              Matplotlib is a community project, maintained for and by its users. 
+              Contribute by answering questions
               <a href="https://discourse.matplotlib.org">on discourse</a>,
               reporting a bug or requesting a feature
               <a href="https://github.com/matplotlib/matplotlib/issues"
                 >on GitHub</a
-              >, or improving the
-              <a href="https://matplotlib.org/stable/devel/index.html"
+              >, and improving the
+              <a href="https://matplotlib.org/devdocs/devel/index.html"
                 >documentation and code</a>!
             </p>
             <a href="https://discourse.matplotlib.org" class="link--offsite"
@@ -428,6 +426,8 @@
               href="https://github.com/matplotlib/matplotlib"
               class="link--offsite"
               >Join us on GitHub</a>
+            <a href="https://matplotlib.org/devdocs/devel/index.html" class="link--offsite"
+              >Read our contributing guide</a>
           </li>
           <li class="callout callout--blue">
             <h4>Cite</h4>


### PR DESCRIPTION
@raphaelquast flagged that we don't link to the contribute guide in the contribute box and that seems bad so added a link here. I'm not a fan of how the white space is distrbuted here but don't wanna mess around with it in this PR.