### PR TITLE
Updated links to change 'users/project/' to 'project/'

### DIFF
--- a/docs/_templates/landing_footer.html
+++ b/docs/_templates/landing_footer.html
@@ -40,11 +40,11 @@
     <li><a href="https://blog.scientific-python.org/tags/matplotlib/">Matplotblog</a></li>
     <li>
       <a
-        href="https://matplotlib.org/stable/users/project/code_of_conduct.html"
+        href="https://matplotlib.org/stable/project/code_of_conduct.html"
         >Code of Conduct</a>
     </li>
     <li>
-      <a href="https://matplotlib.org/stable/users/project/license.html"
+      <a href="https://matplotlib.org/stable/project/license.html"
         >License</a>
     </li>
     <li>

--- a/docs/_templates/landing_footer.html
+++ b/docs/_templates/landing_footer.html
@@ -44,8 +44,7 @@
         >Code of Conduct</a>
     </li>
     <li>
-      <a href="https://matplotlib.org/stable/project/license.html"
-        >License</a>
+      <a href="https://matplotlib.org/stable/project/license.html">License</a>
     </li>
     <li>
       <a href="https://matplotlib.org/governance/">Governance</a>

--- a/docs/body.html
+++ b/docs/body.html
@@ -434,7 +434,7 @@
             <p>
               Matplotlib is the result of development efforts by John Hunter
               (1968&ndash;2012) and the project's
-              <a href="https://matplotlib.org/stable/users/project/credits.html"
+              <a href="https://matplotlib.org/stable/project/credits.html"
                 >many contributors</a>.
             </p>
             <p>
@@ -442,7 +442,7 @@
               publication, please acknowledge this work by citing the project!
             </p>
             <a
-              href="https://matplotlib.org/stable/users/project/citing.html"
+              href="https://matplotlib.org/stable/project/citing.html"
               class="link--offsite"
               >Ready made citation</a>
           </li>


### PR DESCRIPTION
This is part of the [issue](https://github.com/matplotlib/matplotlib/issues/27396) to move non user related material out of `/users`. As part of the first step of moving `/users/project` -> `/doc/project` as is being done in [this PR](https://github.com/matplotlib/matplotlib/pull/27560#pullrequestreview-1814388147), I updated the links to change `users/project/` to `project/`