### PR TITLE
ANN: add 3.10 release to news section

### DIFF
--- a/docs/body.html
+++ b/docs/body.html
@@ -121,6 +121,14 @@
           <!-- optional important news -->
           <h3>News<a class="headerlink" href="#news" title="Permalink to news section">#</a></h3>
           <div class="news__item--highlight">
+            <h5 class="date">Dec 13, 2024</h5>
+            <a href="https://discourse.matplotlib.org/t/matplotlib-announce-ann-matplotlib-3-10-0/25601" class="link--offsite">Matplotlib 3.10.0 Released</a>
+            <p>
+             We thank the 128 authors for the 337 pull requests that comprise the 3.10.0 release.
+            </p>
+          </div>
+              
+          <div class="news__item">
             <h5 class="date">May 30, 2024</h5>
             <a href="https://discourse.matplotlib.org/t/gsoc-2024-announcement/24469" class="link--offsite">GSOC 2024: Bivariate Colormaps</a>
             <p>


### PR DESCRIPTION
Saw that the 3.10 release wasn't added to news and figured it should be.