### PR TITLE
Update chat from gitter to discourse

### DIFF
--- a/docs/body.html
+++ b/docs/body.html
@@ -178,7 +178,7 @@
             Join our community at
             <a href="https://discourse.matplotlib.org">discourse.matplotlib.org</a>
             to get help, share your work, and discuss contributing &amp;
-            development.
+            development on the forum and in chats. 
           </p>
         </div>
 
@@ -198,15 +198,6 @@
             project. Subscribe to our
             <a href="https://scientific-python.org/calendars/">community calendar</a>
             at Scientific Python to get access to all our community meetings.
-          </p>
-        </div>
-
-        <div class="callout__list">
-          <i class="fab fa-gitter callout__icon" aria-hidden="true"></i>
-          <p>
-            Short questions related to contributing to Matplotlib may be posted on the
-            <a href="https://gitter.im/matplotlib/matplotlib">gitter</a>
-            channel.
           </p>
         </div>
       </section>


### PR DESCRIPTION
https://github.com/matplotlib/cheatsheets/pull/186 flagged that the homepage still lists gitter for chat. This PR removes gitter and mentions that discourse is forum+chat.