### PR TITLE
Revert "Turn on back-to-top button"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,7 @@ html_theme_options = {
     "navbar_links": ("absolute", "server-stable"),
     "footer_start": ["landing_footer"],
     "secondary_sidebar_items": [],
-    # commented out to work around https://github.com/matplotlib/mpl-brochure-site/issues/106
-    # "back_to_top_button": False,
+    "back_to_top_button": False,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
The fix to pydata-sphinx-theme was released in 0.17.0 and our theme currently requires 0.18.0, so I think this should work again.

Reverts matplotlib/mpl-brochure-site#108