### PR TITLE
Enable analytics when publishing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,3 +1,4 @@
+---
 name: CI
 
 on: [push, pull_request]
@@ -15,7 +16,11 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements.txt
       - name: Build
-        run: make -Cdocs html
+        run: make -Cdocs html O="-t ${RELEASE_MODE}"
+        env:
+          RELEASE_MODE:
+            ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main')
+                && 'release' || 'dev' }}
       - name: remove inventory
         run: rm ./docs/_build/html/objects.inv
       - name: Publish

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 import datetime
-import subprocess
+
+# Release mode enables optimizations and other related options.
+is_release_build = tags.has('release')  # noqa
 
 # -- Project information -----------------------------------------------------
 
@@ -43,6 +45,11 @@ html_theme_options = {
     # commented out to work around https://github.com/matplotlib/mpl-brochure-site/issues/106
     # "back_to_top_button": False,
 }
+if is_release_build:
+    html_theme_options["analytics"] = {
+        "plausible_analytics_domain": "matplotlib.org",
+        "plausible_analytics_url": "https://views.scientific-python.org/js/script.js"
+    }
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the theme static files,


### PR DESCRIPTION
On our Plausible instance, there are no hits for the toplevel `index.html` because this site is not built with analytics on.